### PR TITLE
issue#20 存在しないスレッドのとき、404を表示

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,0 +1,2 @@
+class Api::ApiController < ActionController::Base
+end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,0 +1,2 @@
+class Api::ApplicationController < ActionController::Base
+end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,2 +1,0 @@
-class Api::ApplicationController < ActionController::Base
-end

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,4 +1,4 @@
-class Api::PostsController < ApplicationController
+class Api::PostsController < Api::ApplicationController
   def index
     @posts = Post.all
   end

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,4 +1,4 @@
-class Api::PostsController < Api::ApplicationController
+class Api::PostsController < Api::ApiController
   def index
     @posts = Post.all
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  private
+
+  def record_not_found
+    render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 Rails.application.routes.draw do
   root 'posts#index'
   resources :users
-  resources :user_sessions
+  resources :user_sessions, only: [:new, :create, :destroy]
   resources :posts do
     resources :comments
   end
   namespace :api, { format: 'json' } do
-    resources :posts , only: [:index, :show]
+    resources :posts, only: [:index, :show]
   end
 
   get 'login' => 'user_sessions#new', as: :login


### PR DESCRIPTION
## 仕様
#### ポスト
- ポストが存在しない時
  - 詳細ページに遷移すると404 Not Foundが表示される
- ポストが存在する時
  - 詳細ページが表示される

#### ユーザー
- ユーザーが存在しない時
  - 詳細ページに遷移すると404 Not Foundが表示される
- ユーザーが存在する時
  - 詳細ページが表示される

#### コメント
- コメントが存在しない時
  - 編集ページに遷移すると404 Not Foundが表示される
- コメントが存在する時
  - 編集ページが表示される

## テストケース

#### ポスト詳細ページテストケース
/posts/:id
- ポストが存在しない時、404NotFoundが表示される
  - レスポンスが404を返す
  - 404.htmlが表示される
- ポストが存在する時、ポストの詳細が表示される
  - ポストのタイトルが表示される
  - ポストの内容が表示される

#### ユーザー詳細ページテストケース
users/:id
- ユーザーが存在しない時、404NotFoundが表示される
  - レスポンスが404を返す
  - 404.htmlが表示される
- ユーザーが存在する時、ユーザーの詳細が表示される
  - ユーザーの名前が表示される
  - ユーザーのメールアドレスが表示される
  - ユーザーの性別が表示される

#### コメント詳細ページテストケース
posts/:id/comments/:id/edit
- コメントが存在しない時、404NotFoundが表示される
  - レスポンスが404を返す
  - 404.htmlが表示される
- コメントが存在する時、コメントの編集ページが表示される
  - コメントの内容が表示される

#### APIテストケース
api/posts/:id
- ポストが存在しない時、404NotFoundが表示される
  - レスポンスが404を返す
  - JSONでstatus: 404が返ってくる
  - JSONでcontent: Not Foundが返ってくる
- ポストが存在する時、ポストの詳細が表示される
  - ポストのタイトルが表示される
  - ポストの内容が表示される
  - コメントの内容とその投稿ユーザー情報が表示される
