### PR TITLE
commentを作成したユーザーのみが編集、削除可能にする #22

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,4 @@
 class CommentsController < ApplicationController
-
   def show
     @post = Post.find(params[:post_id])
     @comment = Comment.find(params[:id])
@@ -26,11 +25,19 @@ class CommentsController < ApplicationController
   def edit
     @post = Post.find(params[:post_id])
     @comment = Comment.find(params[:id])
+    unless @comment.is_commented_by_user?(current_user)
+      redirect_to @post, alert: '他のユーザーのコメントは編集できません。'
+    end
   end
 
   def update
     @post = Post.find(params[:post_id])
     @comment = Comment.find(params[:id])
+
+    unless @comment.is_commented_by_user?(current_user)
+      redirect_to @post, alert: '他のユーザーのコメントは編集できません。'
+    end
+
     if @comment.update(comment_params)
       redirect_to post_path(@post), notice: 'コメントのアップデートが成功しました。'
     else
@@ -42,6 +49,11 @@ class CommentsController < ApplicationController
   def destroy
     @post = Post.find(params[:post_id])
     @comment = Comment.find(params[:id])
+
+    unless @comment.is_commented_by_user?(current_user)
+      redirect_to @post, alert: '他のユーザーのコメントは編集できません。'
+    end
+
     if @comment.destroy
       redirect_to post_path(@comment.post_id), notice: 'コメントが削除されました。'
     else

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,15 +1,17 @@
 class CommentsController < ApplicationController
-  before_action :set_post
-  before_action :set_comment, only: [:show, :edit, :update, :destroy]
 
   def show
+    @post = Post.find(params[:post_id])
+    @comment = Comment.find(params[:id])
   end
 
   def new
+    @post = Post.find(params[:post_id])
     @comment = Comment.new
   end
 
   def create
+    @post = Post.find(params[:post_id])
     @comment = @post.comments.build(comment_params)
     @comment.user_id = current_user.id if current_user
 
@@ -22,9 +24,13 @@ class CommentsController < ApplicationController
   end
 
   def edit
+    @post = Post.find(params[:post_id])
+    @comment = Comment.find(params[:id])
   end
 
   def update
+    @post = Post.find(params[:post_id])
+    @comment = Comment.find(params[:id])
     if @comment.update(comment_params)
       redirect_to post_path(@post), notice: 'コメントのアップデートが成功しました。'
     else
@@ -34,6 +40,8 @@ class CommentsController < ApplicationController
   end
 
   def destroy
+    @post = Post.find(params[:post_id])
+    @comment = Comment.find(params[:id])
     if @comment.destroy
       redirect_to post_path(@comment.post_id), notice: 'コメントが削除されました。'
     else
@@ -46,13 +54,5 @@ class CommentsController < ApplicationController
 
   def comment_params
     params.require(:comment).permit(:content)
-  end
-
-  def set_comment
-    @comment = Comment.find(params[:id])
-  end
-
-  def set_post
-    @post = Post.find(params[:post_id])
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,4 +2,12 @@ class Comment < ApplicationRecord
   belongs_to :post
   belongs_to :user, optional: true
   validates :content, presence: true
+
+  def is_commented_by_user?(user)
+    if user.present?
+      user.id == user_id
+    else
+      false
+    end
+  end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -62,8 +62,7 @@
     <%= comment.created_at %>
   </p>
 
-
-  <% if logged_in? %>
+  <% if comment.is_commented_by_user?(current_user) %>
     <td><%= link_to 'Edit', edit_post_comment_path(comment.post, comment) %></td>
     <td><%= link_to 'Destroy', post_comment_path(comment.post, comment), method: :delete %></td>
   <% end %>


### PR DESCRIPTION
issue#22

## 仕様
- コメントを作成したユーザーとログインユーザーが同じ場合
  - コメントedit画面に遷移して編集できる
  - コメントを削除できる

- コメントを作成したユーザーとログインユーザーが違う場合
  - コメントedit画面に遷移不可、編集できない
  - コメントを削除できない

## テストケース
### ポスト詳細ページテストケース
/posts/:id
- コメントを作成したユーザーとログインユーザーが同じ場合
  - ポストの詳細画面のコメント一覧に編集ボタンが表示される
  - ポストの詳細画面のコメント一覧に削除ボタンが表示される

- コメントを作成したユーザーとログインユーザーが違う場合
  - ポストの詳細画面のコメント一覧に編集ボタンが表示されない
  - ポストの詳細画面のコメント一覧に削除ボタンが表示されない

### コメント編集ページテストケース
/posts/:id/comments/:id/edit
- コメントを作成したユーザーとログインユーザーが同じ場合
  - コメント詳細ページからコメント内容を編集できる

- コメントを作成したユーザーとログインユーザーが違う場合
  - コメント詳細ページに遷移できず、コメント内容が編集できない

### コメント削除ページテストケース
/posts/:id/comments/:id/destroy
- コメントを作成したユーザーとログインユーザーが同じ場合
  - コメントを削除できる
    - ポスト詳細ページのコメント数が１減少

- コメントを作成したユーザーとログインユーザーが違う場合
  - コメントを削除できない

## その他
- 現状、匿名ユーザーのコメントは編集、削除できませんが、別のissueでポストを作成したユーザーのみ、そのポスト内の匿名ユーザーのコメントを編集、削除可能に実装しようと考えています。